### PR TITLE
Fix error screen recieved when trying to open certain recipes

### DIFF
--- a/src/templates/recipe_detail.html
+++ b/src/templates/recipe_detail.html
@@ -31,7 +31,7 @@
             <p>{{step.step}}</p>
             {% endfor %}
         {% else %}
-            See source link above for recipe
+            See <a href="{{recipe.sourceUrl}}">source link</a>
         {% endif %}
     </div>
 </div>


### PR DESCRIPTION
The error message indicated that the recipes that did this lacked a .analizedInstructions[0] property. Looking at the json date, it looks like these recipes have that property equal to [].
Added an if statement to detect this and suggest the user look at the source link listed at the start of the recipe display if they want to see the recipe