### PR TITLE
make print always flush so we can see it in terminal if app crash

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -1,2 +1,3 @@
 FLASK_APP=app.py
 FLASK_ENV=development
+PYTHONUNBUFFERED=true


### PR DESCRIPTION
Our API limit has reached 150 today so the app crashes and no error data can be printed out due to the crash. Adding in `PYTHONUNBUFFERED=true` in the `.flaskenv` file so even if we reach the limit we can still get the error message printed out.
https://stackoverflow.com/questions/59812009/what-is-the-use-of-pythonunbuffered-in-docker-file/59812588
![Screen Shot 2021-10-04 at 9 55 20 PM](https://user-images.githubusercontent.com/15335121/135962570-5e4f4596-d0cc-4ebd-96e1-af48aeb0c93f.png)


