### PR TITLE
Isolate spoon API calls to spoon.py and use a single reference to the API Key

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,11 +1,9 @@
 import requests
 from flask import Flask, render_template, request
-from spoon import searchRecipes
+from spoon import getRecipeDetail, searchRecipes
 
 # flask class instance
 app = Flask(__name__)
-
-API_KEY = '9e749e7df97047c38000f0f4addb64f9'
 
 # / route will show our index template
 @app.route("/")
@@ -28,10 +26,8 @@ def showRecipes():
 
 
 @app.route("/recipe/<recipe_id>")
-def getRecipeDetail(recipe_id):
-    req = f'https://api.spoonacular.com/recipes/{recipe_id}/information?&apiKey={API_KEY}'
-    res = requests.get(req)
-    data = res.json()
+def RecipeDetail(recipe_id):
+    data = getRecipeDetail(recipe_id)
     return render_template('recipe_detail.html', recipe=data)
 
 # test module import

--- a/src/spoon.py
+++ b/src/spoon.py
@@ -1,10 +1,10 @@
 import requests
 
+# API information
+API_KEY = '9e749e7df97047c38000f0f4addb64f9'
 
-def searchRecipes(ingredients, diet, intolerances):
-    # API information
-    API_KEY = '9e749e7df97047c38000f0f4addb64f9'
-    
+
+def searchRecipes(ingredients, diet, intolerances):  
     # basic request
     req = f'https://api.spoonacular.com/recipes/complexSearch?includeIngredients={ingredients}&apiKey={API_KEY}'
 
@@ -24,3 +24,10 @@ def searchRecipes(ingredients, diet, intolerances):
     results = data['results']
     print(results)
     return results
+
+
+def getRecipeDetail(recipe_id):
+    req = f'https://api.spoonacular.com/recipes/{recipe_id}/information?&apiKey={API_KEY}'
+    res = requests.get(req)
+    data = res.json()
+    return data


### PR DESCRIPTION
instead of scattering API methods across our code, lets keep them in the spoon file, and user a single reference to the API_KEY here,

wanted to get this convention going before we continue to add piece of code with scattered API calls.